### PR TITLE
[BUG] Checkbox in the Search History does not function correctly

### DIFF
--- a/src/app/explorative-search/explorative-search-form.component.html
+++ b/src/app/explorative-search/explorative-search-form.component.html
@@ -27,9 +27,9 @@
         <div class="col-md-10 kwArea">
             <ul>
                 <!-- list of all the search keywords by user -->
-                <li class="searchQueries" *ngFor="let keyword of Output">
+                <li class="searchQueries" *ngFor="let keyword of Output; let cbIndex = index;">
                     <span>
-                        <input #kwCheck type="checkbox" (change)="cbInput= kwCheck.checked" checked="true"/> {{keyword.kw}}
+                        <input #kwCheck type="checkbox" (change)="cbInput= kwCheck.checked; hideKW(cbIndex);" checked="true"/> {{keyword.kw}}
                         <span><button class="btn btn-xs btn-danger"
                             (click)="deleteKW(keyword.kw); $event.stopPropagation()"
                             [disabled]=kwCheck.checked
@@ -63,6 +63,7 @@
 <div class="col-12">
     <ul>
         <li *ngFor="let eachOutput of Output; let outerIndex = index">
+          <div [hidden]="showParticularKeyword[outerIndex]">
             <div class="btn-group" role="group" *ngFor="let each of eachOutput.resp.conceptOverview; let innerIndex = index">
                 <button class="btn btn-success" *ngIf="innerIndex === 0 || showMore[outerIndex]" (click)="getQuery(each.url)">{{each.translatedURL}}</button>
             </div>
@@ -70,6 +71,7 @@
                 <button *ngIf="eachOutput.resp.conceptOverview.length > 1" (click)="showMore[outerIndex]=!showMore[outerIndex]">
                     {{showMore[outerIndex] ? 'Hide': 'Show'}} Options</button>
             </div>
+          </div>
         </li>
     </ul>
 </div>

--- a/src/app/explorative-search/explorative-search-form.component.ts
+++ b/src/app/explorative-search/explorative-search-form.component.ts
@@ -2,9 +2,9 @@
  * This file takes care of the Search button and delete Button
  * Search button: upon clicking the keyword response is fetched
  * from server and displayed on the HTML page.
- * 
+ *
  * Delete button: appears once the checkbox beside the keyword is checked
- * upon clicking it the content and the keyword itself are removed from 
+ * upon clicking it the content and the keyword itself are removed from
  * the HTML file
  *
  * Parent for this class: explorative-search.component
@@ -47,6 +47,8 @@ export class ExplorativeSearchFormComponent implements OnInit {
     visData: Object; // send this to details component
     // For response which constitutes more than one option..
     showMore: boolean[] = [];
+    // when unchecked in search history, do not show respective Keywords
+    showParticularKeyword: boolean[] = [];
     private _error_detected_kw = false;
     private _error_detected_query = false;
     private _warning_kw = false;
@@ -56,6 +58,8 @@ export class ExplorativeSearchFormComponent implements OnInit {
     ngOnInit(): void {
         this.showMore = new Array(this.Output.length);
         this.showMore.fill(false);
+        this.showParticularKeyword = new Array(this.Output.length);
+        this.showParticularKeyword.fill(false);
         this.expSearch.getLanguageSupport()
             .then(res => this.availableLanguages = res);
     }
@@ -107,7 +111,19 @@ export class ExplorativeSearchFormComponent implements OnInit {
         if (index > -1) {
             // remove the whole entry from the list
             this.Output.splice(index, 1);
+            // remove visibility 
+            this.showParticularKeyword.splice(index, 1);
         }
+    }
+
+    /**
+    * hideKW: if unchecked the resultant Keywords should be hidden
+    * @param  inputIndex index number of the output keyword that needs to be hidden
+    */
+    hideKW(inputIndex: number) {
+      if (inputIndex > -1) {
+        this.showParticularKeyword[inputIndex] = !this.showParticularKeyword[inputIndex];
+      }
     }
 
     /**


### PR DESCRIPTION
When a keyword in the Search History is unchecked; all possible buttons
below should be hidden. If checked back again, they should appear back again.
This commit resolves this Bug by introducing a boolean array which will hide/unhide
the buttons upon toggling the checkbox.

@jinnerbichler @oliver-jung Bug Fix that would be included in the Demo for the Consortium