### PR TITLE
Adapt the Negotiation for a Product with Query Parameters

### DIFF
--- a/src/app/explorative-search/explorative-search-details.component.html
+++ b/src/app/explorative-search/explorative-search-details.component.html
@@ -31,8 +31,11 @@
                     </button>
                 </div>
                 <div class="col-4 pull-right">
-                    <a class="btn btn-lg btn-primary" (click)="negotiation()" [hidden]="!hiddenElement">
-                        Negotiation</a>
+                    <button class="btn btn-lg btn-primary"
+                    (click)="negotiation()"
+                    [hidden]="!hiddenElement"
+                    [disabled]="!negotiationEnable">
+                        Negotiation</button>
                 </div>
             </div>
             <br>

--- a/src/app/explorative-search/explorative-search-details.component.ts
+++ b/src/app/explorative-search/explorative-search-details.component.ts
@@ -48,7 +48,9 @@ export class ExplorativeSearchDetailsComponent implements AfterViewInit, OnChang
     private _tableJSONPaths = []; // for storing Paths when the figure is rendered again..
     private collectionOfFiltersFromChildren: any[] = []; // filters from the Children Components
     private _optSelectJSON = {};
-    private _negotation_instance_name;
+    private _negotiation_id;
+    private _negotiation_catalogue_id;
+    public negotiationEnable: boolean = false;
 
     /*Final Data to be sent back to parent for processing.*/
     finalSelectionJSON: Object;
@@ -591,6 +593,17 @@ export class ExplorativeSearchDetailsComponent implements AfterViewInit, OnChang
           .then(res => {
               this.sparqlSelectedOption = res;
               this._error_detected_getSPARQLSelect = false;
+              if (this.sparqlSelectedOption['columns'].findIndex(i => i === 'id') >= 0 &&
+                  this.sparqlSelectedOption['columns'].findIndex(j => j === 'catalogueId') >= 0) {
+                  console.log('Negotiation can exist');
+                  this.negotiationEnable = true;
+                  let index_id = this.sparqlSelectedOption['columns'].findIndex(i => i === 'id');
+                  let index_catalogue = this.sparqlSelectedOption['columns'].findIndex(i => i === 'catalogueId');
+                  this._negotiation_id = this.sparqlSelectedOption['rows'][0][index_id];
+                  this._negotiation_catalogue_id = this.sparqlSelectedOption['rows'][0][index_catalogue];
+              } else {
+                  this.negotiationEnable = false;
+              }
           })
             .catch(error => {
                 console.log(error);
@@ -655,10 +668,8 @@ export class ExplorativeSearchDetailsComponent implements AfterViewInit, OnChang
         // console.log(this.selectedProperties); // DEBUG_CHECK
     }
     negotiation(): void {
-        let instance_name_url = this._optSelectJSON['uuid'];
-        console.log(instance_name_url);
-        this._negotation_instance_name = instance_name_url.split('%23')[1];
-        this.router.navigate(['/simple-search-details', this._negotation_instance_name]);
-        // document.location.href = 'http://95.9.71.171:8383/#/simple-search-details/' + this._negotation_instance_name;
+
+        this.router.navigate(['/simple-search-details',
+          { queryParams: {catalogueId: this._negotiation_catalogue_id, id: this._negotiation_id} }]);
     }
 }


### PR DESCRIPTION
- Previous implementation passed the UUID of the Product to
  `simple-search-details`
- This commit adds the `catalogueId` and `id` query Parameters
  to reroute within the App for the Negotiation