### PR TITLE
[HotFix] Wrong bracket placement causes the rerouting to fail

### DIFF
--- a/src/app/explorative-search/explorative-search-details.component.ts
+++ b/src/app/explorative-search/explorative-search-details.component.ts
@@ -669,7 +669,7 @@ export class ExplorativeSearchDetailsComponent implements AfterViewInit, OnChang
     }
     negotiation(): void {
 
-        this.router.navigate(['/simple-search-details',
-          { queryParams: {catalogueId: this._negotiation_catalogue_id, id: this._negotiation_id} }]);
+        this.router.navigate(['/simple-search-details'],
+          { queryParams: {catalogueId: this._negotiation_catalogue_id, id: this._negotiation_id} });
     }
 }


### PR DESCRIPTION
- the path bracket within the router.navigate function was placed wrong.
- this commit fixes this hotfix