### PR TITLE
[UB] Add Apache2.0 Boilerplate to Frontend Components

### DIFF
--- a/src/app/explorative-search/explorative-search-details.component.css
+++ b/src/app/explorative-search/explorative-search-details.component.css
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * StyleSheet for Explorative Search Details
  */
 /*.displayArea {*/

--- a/src/app/explorative-search/explorative-search-details.component.css
+++ b/src/app/explorative-search/explorative-search-details.component.css
@@ -38,9 +38,9 @@
     /*background-color: #dddddd;*/
 /*}*/
 
-.node circle {
+/* .node circle { */
     /* fill: #999; */
-}
+/* } */
 
 .node text {
     font: 14px sans-serif;

--- a/src/app/explorative-search/explorative-search-details.component.html
+++ b/src/app/explorative-search/explorative-search-details.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. --> 
+
 <!-- Explorative Search Details HTML -->
 <ngb-alert type="info" *ngIf="!introAlert" (close)="introAlert = true">
     <div class="row">

--- a/src/app/explorative-search/explorative-search-details.component.ts
+++ b/src/app/explorative-search/explorative-search-details.component.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import {Component, AfterViewInit, Input, OnChanges, ViewEncapsulation} from '@angular/core';
 import * as d3 from 'd3';
 import { ExplorativeSearchService } from './explorative-search.service';

--- a/src/app/explorative-search/explorative-search-filter.component.css
+++ b/src/app/explorative-search/explorative-search-filter.component.css
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * StyleSheet for Explorative Search Filter
  */
 .filterArea {

--- a/src/app/explorative-search/explorative-search-filter.component.html
+++ b/src/app/explorative-search/explorative-search-filter.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <!-- Explorative Search Filter HTML -->
 
 <!-- Display the Filter Panel only when the filterConfig is non empty -->

--- a/src/app/explorative-search/explorative-search-filter.component.ts
+++ b/src/app/explorative-search/explorative-search-filter.component.ts
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * Filter Functionality on Clicking A Node.
  * This component handles the filter panel that appears
  * after a node on the Diagram is clicked.

--- a/src/app/explorative-search/explorative-search-form.component.css
+++ b/src/app/explorative-search/explorative-search-form.component.css
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * Style Sheet for Explorative Search Form
 */
 .kwArea {

--- a/src/app/explorative-search/explorative-search-form.component.html
+++ b/src/app/explorative-search/explorative-search-form.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <!-- Explorative Search Form HTML -->
 <!-- Search Bar -->
 

--- a/src/app/explorative-search/explorative-search-form.component.ts
+++ b/src/app/explorative-search/explorative-search-form.component.ts
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * This file takes care of the Search button and delete Button
  * Search button: upon clicking the keyword response is fetched
  * from server and displayed on the HTML page.

--- a/src/app/explorative-search/explorative-search-routing.module.ts
+++ b/src/app/explorative-search/explorative-search-routing.module.ts
@@ -21,12 +21,12 @@ import { Routes, RouterModule } from '@angular/router';
 import {ExplorativeSearchComponent} from './explorative-search.component';
 
 const routes: Routes = [
-	{path: '', component: ExplorativeSearchComponent}
+    {path: '', component: ExplorativeSearchComponent}
 ];
 
 @NgModule({
-	imports: [ RouterModule.forChild(routes) ],
-	exports: [ RouterModule ]
+    imports: [ RouterModule.forChild(routes) ],
+    exports: [ RouterModule ]
 })
 
 export class ExplorativeSearchRoutingModule {}

--- a/src/app/explorative-search/explorative-search-routing.module.ts
+++ b/src/app/explorative-search/explorative-search-routing.module.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 

--- a/src/app/explorative-search/explorative-search-semantic.component.css
+++ b/src/app/explorative-search/explorative-search-semantic.component.css
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 /*Column Highlighting*/
 /*table {*/
     /*overflow: hidden;*/

--- a/src/app/explorative-search/explorative-search-semantic.component.html
+++ b/src/app/explorative-search/explorative-search-semantic.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <ngb-alert type="info" *ngIf="infoAlert" (close)="infoAlert = false">
     <div class="row">
         <div class="col-md-2">

--- a/src/app/explorative-search/explorative-search-semantic.component.ts
+++ b/src/app/explorative-search/explorative-search-semantic.component.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import {Component, Input, OnChanges, OnInit, ViewChild} from '@angular/core';
 import { Router } from '@angular/router';
 import {ExplorativeSearchService} from './explorative-search.service';

--- a/src/app/explorative-search/explorative-search.component.css
+++ b/src/app/explorative-search/explorative-search.component.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/explorative-search/explorative-search.component.html
+++ b/src/app/explorative-search/explorative-search.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <!-- For Modularity: everything is moved to
 the Angular Component of explore-search-form -->
 <!-- see the explorative-search-form.component.html for details -->

--- a/src/app/explorative-search/explorative-search.component.ts
+++ b/src/app/explorative-search/explorative-search.component.ts
@@ -1,4 +1,22 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
+/**
  * This file is the main Angular component
  * for the explorative-search of the App.
  * For Modularity Designs all the components are in:

--- a/src/app/explorative-search/explorative-search.module.ts
+++ b/src/app/explorative-search/explorative-search.module.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';

--- a/src/app/explorative-search/explorative-search.service.ts
+++ b/src/app/explorative-search/explorative-search.service.ts
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * This is the Service File for the Explorative Search Component.
  * We Inject a simple HTTP GET Service which will perform a GET on
  * the User's keyword input to the backend server.

--- a/src/app/explorative-search/model/explorative.ts
+++ b/src/app/explorative-search/model/explorative.ts
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
  * This is how the keyword search and its respective
  * response is Modelled.
  * Both values will be strings.

--- a/src/app/explorative-search/model/search.ts
+++ b/src/app/explorative-search/model/search.ts
@@ -17,7 +17,7 @@
 
 
 export class Search {
-	constructor(
-		public q: string
-	) {  }
+    constructor(
+        public q: string
+    ) {  }
 }

--- a/src/app/explorative-search/model/search.ts
+++ b/src/app/explorative-search/model/search.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
 export class Search {
 	constructor(
 		public q: string

--- a/src/app/qualiexplore/factors/factors.component.css
+++ b/src/app/qualiexplore/factors/factors.component.css
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 .fa-flag {
     color: red;
     margin-right: 10px;

--- a/src/app/qualiexplore/factors/factors.component.html
+++ b/src/app/qualiexplore/factors/factors.component.html
@@ -1,3 +1,19 @@
+<!-- 
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <ng-template #itemTemplate let-item="item" let-onCollapseExpand="onCollapseExpand" let-onCheckedChange="onCheckedChange">
     <div class="form-inline row-item">
       <i *ngIf="item.children" (click)="onCollapseExpand()" aria-hidden="true" class="fas mr-3"

--- a/src/app/qualiexplore/factors/factors.component.ts
+++ b/src/app/qualiexplore/factors/factors.component.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FactorsService } from './factors.service';

--- a/src/app/qualiexplore/factors/factors.service.ts
+++ b/src/app/qualiexplore/factors/factors.service.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { TreeviewItem } from 'ngx-treeview';

--- a/src/app/qualiexplore/factors/factors.service.ts
+++ b/src/app/qualiexplore/factors/factors.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { TreeviewItem } from 'ngx-treeview';
+// import { TreeviewItem } from 'ngx-treeview';
 
 @Injectable()
 

--- a/src/app/qualiexplore/filters/filters.component.css
+++ b/src/app/qualiexplore/filters/filters.component.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/qualiexplore/filters/filters.component.html
+++ b/src/app/qualiexplore/filters/filters.component.html
@@ -1,3 +1,19 @@
+<!--
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <div class="container mt-5">
     <h2><span [innerHTML]="'QualiExplore' | translate"></span></h2>
     <div class="mt-lg-auto jumbotron">

--- a/src/app/qualiexplore/filters/filters.component.ts
+++ b/src/app/qualiexplore/filters/filters.component.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component, OnInit } from '@angular/core';
 import { FiltersService } from './filters.service';
 import { Router } from '@angular/router';

--- a/src/app/qualiexplore/filters/filters.service.ts
+++ b/src/app/qualiexplore/filters/filters.service.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 

--- a/src/app/qualiexplore/filters/model/filter.ts
+++ b/src/app/qualiexplore/filters/model/filter.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 export interface Label {
     id: number;
     name: string;

--- a/src/app/qualiexplore/qualiexplore-routing.module.ts
+++ b/src/app/qualiexplore/qualiexplore-routing.module.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { FiltersComponent } from './filters/filters.component';

--- a/src/app/qualiexplore/qualiexplore.component.css
+++ b/src/app/qualiexplore/qualiexplore.component.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020 
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/qualiexplore/qualiexplore.component.html
+++ b/src/app/qualiexplore/qualiexplore.component.html
@@ -1,2 +1,18 @@
+<!--
+ * Copyright 2020 
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <h1>QualiExplore Component</h1>
 <!-- Redirect to Filters-->

--- a/src/app/qualiexplore/qualiexplore.component.ts
+++ b/src/app/qualiexplore/qualiexplore.component.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component } from '@angular/core';
 
 @Component({

--- a/src/app/qualiexplore/qualiexplore.module.ts
+++ b/src/app/qualiexplore/qualiexplore.module.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2020
+ * University of Bremen, Faculty of Production Engineering, Badgasteiner Straße 1, 28359 Bremen, Germany.
+ * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';

--- a/src/app/tnt/model/SafePipe.ts
+++ b/src/app/tnt/model/SafePipe.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Pipe, PipeTransform } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 

--- a/src/app/tnt/model/search.ts
+++ b/src/app/tnt/model/search.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 export class Search {
     constructor(
         public q: string

--- a/src/app/tnt/model/trackinfo.ts
+++ b/src/app/tnt/model/trackinfo.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 export interface TrackInfo {
     epc: string,
     eventTime: string;

--- a/src/app/tnt/tnt-event-data.component.css
+++ b/src/app/tnt/tnt-event-data.component.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 /* The actual timeline (the vertical ruler) */
 /* .scroll-container {
   display: flex;

--- a/src/app/tnt/tnt-event-data.component.html
+++ b/src/app/tnt/tnt-event-data.component.html
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <div class="container-fluid"  *ngIf="incomingTrackingInfo.length">
     <div class="row mt-3">
         <div class="col-sm-12">

--- a/src/app/tnt/tnt-event-data.component.ts
+++ b/src/app/tnt/tnt-event-data.component.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component, Input, OnChanges } from '@angular/core';
 import { TrackInfo } from './model/trackinfo';
 import * as myGlobals from '../globals';

--- a/src/app/tnt/tnt-event-details.component.css
+++ b/src/app/tnt/tnt-event-details.component.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/tnt/tnt-event-details.component.html
+++ b/src/app/tnt/tnt-event-details.component.html
@@ -1,3 +1,18 @@
+<!-- 
+   Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <div class="jumbotron" *ngIf="!gateInformation.length && !bizLocationInformation.length">
     <div class="row">
         <div class="col-md-12 align-center">

--- a/src/app/tnt/tnt-event-details.component.ts
+++ b/src/app/tnt/tnt-event-details.component.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { TrackInfo } from './model/trackinfo';
 import * as myGlobals from '../globals';

--- a/src/app/tnt/tnt-form.component.css
+++ b/src/app/tnt/tnt-form.component.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/tnt/tnt-form.component.html
+++ b/src/app/tnt/tnt-form.component.html
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. -->
+
 <div>
     <p class="nimble-title"><span [innerHTML]="'Track Your Product' | translate"></span></p>
     <form class="space-before" (ngSubmit)="Search(model.q)" #trackForm="ngForm" novalidate>

--- a/src/app/tnt/tnt-form.component.ts
+++ b/src/app/tnt/tnt-form.component.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component } from '@angular/core';
 import { Search } from './model/search';
 import { TnTService } from './tnt.service';

--- a/src/app/tnt/tnt-routing.module.ts
+++ b/src/app/tnt/tnt-routing.module.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 

--- a/src/app/tnt/tnt.component.css
+++ b/src/app/tnt/tnt.component.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+ 

--- a/src/app/tnt/tnt.component.html
+++ b/src/app/tnt/tnt.component.html
@@ -1,1 +1,16 @@
+  <!-- Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ -->
+
 <tnt-form></tnt-form>

--- a/src/app/tnt/tnt.component.ts
+++ b/src/app/tnt/tnt.component.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Component } from '@angular/core';
 
 @Component({

--- a/src/app/tnt/tnt.module.ts
+++ b/src/app/tnt/tnt.module.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { NgModule } from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import { HttpModule } from '@angular/http';

--- a/src/app/tnt/tnt.service.ts
+++ b/src/app/tnt/tnt.service.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Universität Bremen/BIBA - Bremer Institut für Produktion und Logistik GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 import { Injectable } from '@angular/core';
 import { Http, URLSearchParams, Headers, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';


### PR DESCRIPTION
- Add boilerplate for Apache2.0 License as mentioned in the LICENSE file
  all Universität Bremen developed Frontend Components
- Copyright in accordance with Apache2.0 License for:
    * Universität Bremen, Faculty of Production Engineering, Badgasteinerstr. 1, Bremen, Germany
    * In collaboration with BIBA - Bremer Institut für Produktion und Logistik GmbH, Bremen, Germany

- Improve linting for some files within components
    
